### PR TITLE
bugfix: 解决加密压缩文件太大的oom 问题，原因是计算hash值的时候会将全部数据读到内存

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -145,10 +145,11 @@ func xorBytes(dst, a, b []byte) int {
 // recommended if: 1. you buffer the data yourself and wait for authentication
 // before streaming to another source such as the network, or 2. you just don't
 // care about authenticating unknown ciphertext before use :).
-func newAuthReader(akey []byte, data, adata io.Reader, streaming bool) io.Reader {
+func newAuthReader(akey []byte, data, rdata, adata io.Reader, streaming bool) io.Reader {
 	ar := authReader{
 		data:  data,
 		adata: adata,
+		rdata: rdata,
 		mac:   hmac.New(sha1.New, akey),
 		err:   nil,
 		auth:  false,
@@ -158,13 +159,13 @@ func newAuthReader(akey []byte, data, adata io.Reader, streaming bool) io.Reader
 	}
 	return &bufferedAuthReader{
 		ar,
-		new(bytes.Buffer),
 	}
 }
 
 // Streaming authentication
 type authReader struct {
 	data  io.Reader // data to be authenticated
+	rdata io.Reader // data to be return
 	adata io.Reader // the authentication code to read
 	mac   hash.Hash // hmac hash
 	err   error
@@ -210,7 +211,6 @@ func (a *authReader) Read(p []byte) (int, error) {
 // buffered authentication
 type bufferedAuthReader struct {
 	authReader
-	buf *bytes.Buffer // buffer to store data to authenticate
 }
 
 func (a *bufferedAuthReader) Read(b []byte) (int, error) {
@@ -220,7 +220,7 @@ func (a *bufferedAuthReader) Read(b []byte) (int, error) {
 	}
 	// make sure we have auth'ed before we send any data
 	if !a.auth {
-		_, err := io.Copy(a.buf, a.data)
+		_, err := io.Copy(a.mac, a.data)
 		if err != nil {
 			a.err = err
 			return 0, a.err
@@ -234,18 +234,13 @@ func (a *bufferedAuthReader) Read(b []byte) (int, error) {
 			a.err = ErrDecryption
 			return 0, a.err
 		}
-		_, err = a.mac.Write(a.buf.Bytes())
-		if err != nil {
-			a.err = err
-			return 0, a.err
-		}
 		if !a.checkAuthentication(ab.Bytes()) {
 			a.err = ErrAuthentication
 			return 0, a.err
 		}
 	}
 	// so we've authenticated the data, now just pass it on.
-	n, err := a.buf.Read(b)
+	n, err := a.rdata.Read(b)
 	if err != nil {
 		a.err = err
 	}
@@ -303,9 +298,10 @@ func newDecryptionReader(r *io.SectionReader, f *File) (io.Reader, error) {
 	// f.CompressedSize64 = uint64(dataLen)
 	// f.CompressedSize = uint32(dataLen)
 	data := io.NewSectionReader(r, dataOff, dataLen)
+	rdata := io.NewSectionReader(r, dataOff, dataLen)
 	authOff := dataOff + dataLen
 	authcode := io.NewSectionReader(r, authOff, 10)
-	ar := newAuthReader(authKey, data, authcode, f.DeferAuth)
+	ar := newAuthReader(authKey, data, rdata, authcode, f.DeferAuth)
 	dr := decryptStream(decKey, ar)
 	if dr == nil {
 		return nil, ErrDecryption


### PR DESCRIPTION
读zip加密文件时，会将所有数据读到内存，然后计算hash值，如果遇到内存不高并且压缩文件较大的情况，会直接oom